### PR TITLE
Escape string with triple quotes

### DIFF
--- a/helpers/mu/sparql.js
+++ b/helpers/mu/sparql.js
@@ -73,7 +73,7 @@ function query( queryString ) {
 const update = query;
 
 function sparqlEscapeString( value ){
-  return '"' + value.replace(/[\\"']/g, function(match) { return '\\' + match; }) + '"';
+  return '"""' + value.replace(/[\\"']/g, function(match) { return '\\' + match; }) + '"""';
 };
 
 function sparqlEscapeUri( value ){


### PR DESCRIPTION
Virtuoso doesn't accept single quoted strings that have new lines
inside. By using three quotes to escape them, this case is handled.