### PR TITLE
Use `exec` in boot.sh and Node.js scripts to enable use of signals

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -16,21 +16,21 @@ if [ "$NODE_ENV" == "development" ] && [ "$IMAGE_STATUS" == "template" ]
 then
   copyFolderAndInstall;
   #run daemon and watch mounted app folder
-  npm run daemon;
+  exec npm run daemon;
 elif [ "$NODE_ENV" == "production" ] && [ "$IMAGE_STATUS" == "template" ]
 then
   copyFolderAndInstall;
   #build production app
   npm run build;
   #run production app
-  npm run node-prod;
+  exec npm run node-prod;
 elif [ "$NODE_ENV" == "development" ] && [ "$IMAGE_STATUS" == "standalone" ]
 then
   copyFolderAndInstall
   #run daemon and watch mounted app folder
-  npm run daemon;
+  exec npm run daemon;
 elif [ "$NODE_ENV" == "production" ] && [ "$IMAGE_STATUS" == "standalone" ]
 then
   #run production app
-  npm run node-prod;
+  exec npm run node-prod;
 fi

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.4.0",
   "description": "Template for mu services written in JavaScript",
   "scripts": {
-    "daemon": "nodemon --watch /app --ext js,mjs,cjs,json --exec ./run.sh",
+    "daemon": "exec nodemon --watch /app --ext js,mjs,cjs,json --exec ./run.sh",
     "babel-node-dev": "babel-node --inspect=0.0.0.0:9229 ./start-dev.js",
     "build": "babel ./ --ignore \"./start-prod.js\",\"./start-dev.js\",\"./prod\",\"./node_modules\" --out-dir ./prod",
-    "node-prod": "node ./start-prod.js"
+    "node-prod": "exec node ./start-prod.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using `exec` here means that the called command will replace the shell
process used to invoke the command. This is a simple way to allow
signals (such as a SIGTERM sent by `docker stop`) to propagate from the
main process to the actual application process that may want to listen
to these signals.

This is necessary for https://github.com/redpencilio/docker-network-capture-service/commit/22342dabccb6f94e7dcbaca1ab265b747cbdc6eb to work.