### PR TITLE
for prod builds make sure babel copies non js files as well

### DIFF
--- a/build-production.sh
+++ b/build-production.sh
@@ -26,4 +26,4 @@ mkdir -p /usr/src/output/node_modules
 cp -R /usr/src/app/node_modules /usr/src/output/
 
 ## Build microservice sources
-/usr/src/app/node_modules/.bin/babel /usr/src/app/ --ignore node_modules --copy-files --out-dir /usr/src/output
+/usr/src/app/node_modules/.bin/babel /usr/src/app/ --ignore node_modules --copy-files --no-copy-ignored --out-dir /usr/src/output

--- a/build-production.sh
+++ b/build-production.sh
@@ -26,4 +26,4 @@ mkdir -p /usr/src/output/node_modules
 cp -R /usr/src/app/node_modules /usr/src/output/
 
 ## Build microservice sources
-/usr/src/app/node_modules/.bin/babel /usr/src/app/ --ignore node_modules --out-dir /usr/src/output
+/usr/src/app/node_modules/.bin/babel /usr/src/app/ --ignore node_modules --copy-files --out-dir /usr/src/output


### PR DESCRIPTION
services might use json files, hbs files etc. I believe you need to add the --copy-files directive to instruct babel to also copy these files.
See https://babeljs.io/docs/en/babel-cli#copy-files