### PR TITLE
add a "test" mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.16.1-alpine
 
 LABEL maintainer="madnificent@gmail.com"
 
-RUN apk update && apk upgrade && apk add --no-cache bash git jq
+RUN apk update && apk upgrade && apk add --no-cache bash git jq openssh
 
 ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
 ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.16.1-alpine
 
 LABEL maintainer="madnificent@gmail.com"
 
-RUN apk update && apk upgrade && apk add --no-cache bash git openssh
+RUN apk update && apk upgrade && apk add --no-cache bash git jq
 
 ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
 ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ When running inside a mu.semte.ch stack, you could mount your sources and connec
 Now open Chromium, and visit [chrome://inspect/](chrome://inspect/).  Once the service is launched, a remote target on localhost should pop up.
 
 ## Running tests [BETA]
-The javascript template provides [mocha]() as a testing framework. Create a `test` folder in your application root and nest any tests under that folder. 
+The javascript template provides [mocha](https://mochajs.org/#getting-started) as a testing framework. Create a `test` folder in your application root and nest any tests under that folder. 
 You can run tests by setting the `NODE_ENV` to "test":
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -177,3 +177,16 @@ When running inside a mu.semte.ch stack, you could mount your sources and connec
         - /absolute/path/to/your/sources/:/app/
 ```
 Now open Chromium, and visit [chrome://inspect/](chrome://inspect/).  Once the service is launched, a remote target on localhost should pop up.
+
+## Running tests [BETA]
+The javascript template provides [mocha]() as a testing framework. Create a `test` folder in your application root and nest any tests under that folder. 
+You can run tests by setting the `NODE_ENV` to "test":
+```
+```
+docker run
+       --rm
+       -v `pwd`:/app \
+       -e NODE_ENV=test \
+       --name my-js-test \
+       semtech/mu-javascript-template
+```

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Now open Chromium, and visit [chrome://inspect/](chrome://inspect/).  Once the s
 ## Running tests [BETA]
 The javascript template provides [mocha]() as a testing framework. Create a `test` folder in your application root and nest any tests under that folder. 
 You can run tests by setting the `NODE_ENV` to "test":
-```
-```
+
+```bash
 docker run
        --rm
        -v `pwd`:/app \

--- a/boot.sh
+++ b/boot.sh
@@ -3,8 +3,11 @@ then
     # Run live-reload development
     exec /usr/src/app/node_modules/.bin/nodemon \
          --watch /app \
-         --ext js,mjs,cjs,json \
+         --ext js,mjs,cjs,json,hbs \
          --exec /usr/src/app/run-development.sh
+elif [ "$NODE_ENV" == "test" ]
+then
+    exec /usr/src/app/run-test.sh
 elif [ "$NODE_ENV" == "production" ]
 then
     diff -rq /app /app.original > /dev/null

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/mu-semtech/mu-javascript-template.git"
   },
+  "scripts": {
+    "test": "mocha --require @babel/register"
+  },
   "keywords": [
     "mu-semtech"
   ],
@@ -16,11 +19,13 @@
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-proposal-decorators": "^7.13.15",
     "@babel/preset-env": "^7.14.1",
+    "@babel/register": "^7.13.16",
     "babel-plugin-module-resolver": "4.1.0",
     "body-parser": "~1.19.0",
     "env-var": "^7.0.0",
     "express": "^4.17.1",
     "express-http-context": "~1.2.4",
+    "mocha": "^8.4.0",
     "nodemon": "^2.0.7",
     "sparql-client-2": "https://github.com/erikap/node-sparql-client.git",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/mu-semtech/mu-javascript-template.git"
   },
   "scripts": {
-    "test": "mocha --require @babel/register"
+    "test": "mocha --require @babel/register --exit"
   },
   "keywords": [
     "mu-semtech"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mu-javascript-template",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0-beta.2",
   "description": "Template for mu services written in JavaScript",
   "repository": {
     "type": "git",

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# create a copy of app, so we can modify as necessary
+cp -a /app /usr/src/out
+
+# add some required files from the template
+cp -a /usr/src/app/.babelrc.js /usr/src/app/helpers /usr/src/out/
+# merge package.json files, prefering whatever is specified in the app
+jq -s '.[0] * .[1]' /usr/src/app/package.json  /app/package.json > /usr/src/out/package.json
+
+# do things
+cd /usr/src/out
+npm install
+npm test

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 # create a copy of app, so we can modify as necessary
-cp -a /app /usr/src/out
+cp -a /app /usr/src/output
 
 # add some required files from the template
-cp -a /usr/src/app/.babelrc.js /usr/src/app/helpers /usr/src/out/
+cp -a /usr/src/app/.babelrc.js /usr/src/app/helpers /usr/src/output/
 # merge package.json files, prefering whatever is specified in the app
-jq -s '.[0] * .[1]' /usr/src/app/package.json  /app/package.json > /usr/src/out/package.json
+jq -s '.[0] * .[1]' /usr/src/app/package.json  /app/package.json > /usr/src/output/package.json
 
 # do things
-cd /usr/src/out
+cd /usr/src/output
 npm install
 npm test


### PR DESCRIPTION
this mode works differently from dev in that it creates a merged package.json file, so we have both the dependencies of the template and of the app available. In case of overlapping keys the values from the app are preferred over those from the template. This is typically a requirement to successfully run tests, and may also be considered as a sane approach for the dev script.

Merging of the package.json files is done using jq's multiply function and probably has some limitations I'm currently not aware of. So far it seems to be working.