### PR TITLE
Update sparqlEscapeUri regex

### DIFF
--- a/helpers/mu/sparql.js
+++ b/helpers/mu/sparql.js
@@ -104,7 +104,7 @@ function sparqlEscapeString( value ){
 };
 
 function sparqlEscapeUri( value ){
-  return '<' + value.replace(/[\\"']/g, function(match) { return '\\' + match; }) + '>';
+  return '<' + value.replace(/[\\"<>]/g, function(match) { return '\\' + match; }) + '>';
 };
 
 function sparqlEscapeInt( value ){


### PR DESCRIPTION
There is no need to escape single quotes in URIs, which can cause errors then in virtuoso when inserting espaces `'`, but there is the need to escape `<` and `>` to avoid injections.