### PR TITLE
Support for /config folder

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -9,18 +9,33 @@ then
 elif [ "$NODE_ENV" == "production" ]
 then
     diff -rq /app /app.original > /dev/null
-    FILES_CHANGED="$?"
+    APP_FILES_CHANGED="$?"
+    diff -rq /config /config.original > /dev/null
+    CONFIG_FILES_CHANGED="$?"
 
     if [ ! -f /usr/src/output/app/app.js ]
     then
         echo "No built sources found.  If you mount new sources, please set the NODE_ENV=\"development\" environment variable."
         sleep 5;
         exit 1;
-    elif [ $FILES_CHANGED != "0" ]
+    elif [ $APP_FILES_CHANGED != "0" ]
     then
         echo "Built sources are not the same as sources available in /app.  If you mount new sources, please set the NODE_ENV=\"development\" environment variable."
         sleep 5;
         exit 1;
+    elif [ $CONFIG_FILES_CHANGED != "0" ]
+    then
+        echo "Rebuilding sources to include /config."
+
+        cp -Rf /config/* /usr/src/app/app/config/
+
+        /usr/src/app/node_modules/.bin/babel /usr/src/app/ \
+             --ignore app/node_modules,node_modules \
+             --copy-files --no-copy-ignored \
+             --out-dir /usr/src/output
+
+        cd /usr/src/output/
+        exec node ./app/app.js
     else
         cd /usr/src/output/
         exec node ./app/app.js

--- a/boot.sh
+++ b/boot.sh
@@ -3,6 +3,7 @@ then
     # Run live-reload development
     exec /usr/src/app/node_modules/.bin/nodemon \
          --watch /app \
+         --watch /config \
          --ext js,mjs,cjs,json \
          --exec /usr/src/app/run-development.sh
 elif [ "$NODE_ENV" == "production" ]

--- a/build-production.sh
+++ b/build-production.sh
@@ -10,7 +10,9 @@
 cd /usr/src/app
 rm -rf ./app /app.original
 cp -r /app ./
+mkdir -p /config; mkdir -p ./app/config; cp -rf /config/* ./app/config/ 2> /dev/null
 cp -r /app /app.original
+cp -r /config /config.original
 
 # Install custom packages if need be
 if [ -f ./app/package.json ]

--- a/run-development.sh
+++ b/run-development.sh
@@ -22,8 +22,9 @@ mv ./app/node_modules /tmp/node_modules
 rm -rf ./app
 mkdir ./app
 mv /tmp/node_modules ./app/
-# Copy app folder (including node_modules so host node_modules win)
+# Copy app folder and config folder (including node_modules so host node_modules win)
 cp -rf /app ./
+mkdir -p /config/; mkdir -p ./app/config/; cp -rf /config/* ./app/config/;
 
 # Install dependencies on first boot
 if [ $CHANGE_IN_PACKAGE_JSON != "0" ] && [ -f ./app/package.json ]


### PR DESCRIPTION
The config folder is available under the `/app` folder.  When files are present in this folder, compilation happens at first boot.  During development, live reload is offered for the `/config` folder.

Current *implementation* allows for users to override config files.  This allows the app to provide a default configuration for files users may override.  I consider this experimental and would certainly like input on how desired this approach is.