### PR TITLE
add expose statement to document exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY . /usr/src/app
 RUN chmod +x /usr/src/app/run-development.sh
 RUN chmod +x /usr/src/app/build-production.sh
 
+EXPOSE 80
+
 CMD sh boot.sh
 
 # This stuff only runs when building an image from the template


### PR DESCRIPTION
I was kind of surprised we didn't have this in here already. 
the [docker reference](https://docs.docker.com/engine/reference/builder/#expose) specifies this is mostly for documentation towards users of a microservice. I think it's valuable to make it clear that microservices based on the template listen on port 80. Exposed ports are  also used by other "proxy type" microservices such as the letsencrypt companion to figure out how to forward calls to the container in question.

From the reference:
> The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. You can specify whether the port listens on TCP or UDP, and the default is TCP if the protocol is not specified.

> The EXPOSE instruction does not actually publish the port. It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published. To actually publish the port when running the container, use the -p flag on docker run to publish and map one or more ports, or the -P flag to publish all exposed ports and map them to high-order ports.