### PR TITLE
Allow overriding port and hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ ENV NODE_ENV 'production'
 ENV HOST '0.0.0.0'
 ENV PORT '80'
 
-ENV NODE_ENV 'production'
-
 ENV LOG_SPARQL_ALL 'true'
 ENV DEBUG_AUTH_HEADERS 'true'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
 ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'
 ENV NODE_ENV 'production'
 
+ENV HOST '0.0.0.0'
+ENV PORT '80'
+
+ENV NODE_ENV 'production'
+
 ENV LOG_SPARQL_ALL 'true'
 ENV DEBUG_AUTH_HEADERS 'true'
 
@@ -19,7 +24,7 @@ COPY . /usr/src/app
 RUN chmod +x /usr/src/app/run-development.sh
 RUN chmod +x /usr/src/app/build-production.sh
 
-EXPOSE 80
+EXPOSE ${PORT}
 
 CMD sh boot.sh
 

--- a/helpers/mu/server.js
+++ b/helpers/mu/server.js
@@ -4,6 +4,8 @@ import bodyParser from 'body-parser';
 
 var app = express();
 
+var port = process.env.PORT || '80';
+var hostname = process.env.HOST || '0.0.0.0';
 var bodySizeLimit = process.env.MAX_BODY_SIZE || '100kb';
 
 // parse JSONAPI content type
@@ -35,7 +37,7 @@ const errorHandler = function(err, req, res, next) {
 };
 
 // start server
-app.listen( 80, function() {
+app.listen( port, hostname, function() {
   console.log(`Starting server on port 80 in ${app.get('env')} mode`);
 });
 

--- a/helpers/mu/server.js
+++ b/helpers/mu/server.js
@@ -38,7 +38,7 @@ const errorHandler = function(err, req, res, next) {
 
 // start server
 app.listen( port, hostname, function() {
-  console.log(`Starting server on port 80 in ${app.get('env')} mode`);
+  console.log(`Starting server on ${hostname}:${port} in ${app.get('env')} mode`);
 });
 
 export default app;


### PR DESCRIPTION
Some environments require a different port or hostname (0.0.0.0:80 is not allowed for non-root users in Openshift).

We could add [dotenv-defaults](https://github.com/mrsteele/dotenv-defaults).