### PR TITLE
Merge master in feature-node-16-support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY . /usr/src/app
 RUN chmod +x /usr/src/app/run-development.sh
 RUN chmod +x /usr/src/app/build-production.sh
 
+EXPOSE 80
+
 CMD sh boot.sh
 
 # This stuff only runs when building an image from the template

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
 ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'
 ENV NODE_ENV 'production'
 
+ENV HOST '0.0.0.0'
+ENV PORT '80'
+
 ENV LOG_SPARQL_ALL 'true'
 ENV DEBUG_AUTH_HEADERS 'true'
 
@@ -19,7 +22,7 @@ COPY . /usr/src/app
 RUN chmod +x /usr/src/app/run-development.sh
 RUN chmod +x /usr/src/app/build-production.sh
 
-EXPOSE 80
+EXPOSE ${PORT}
 
 CMD sh boot.sh
 

--- a/README.md
+++ b/README.md
@@ -196,3 +196,20 @@ When running inside a mu.semte.ch stack, you could mount your sources and connec
         - /absolute/path/to/your/sources/:/app/
 ```
 Now open Chromium, and visit [chrome://inspect/](chrome://inspect/).  Once the service is launched, a remote target on localhost should pop up.
+
+## Handling Delta's
+If you are building a reactive service that should execute certain logic based on changes in the database, you want to hook it up to the [delta-notifier](https://github.com/mu-semtech/delta-notifier/). Some extra steps need to be taken to properly handle delta's, specifically the route handling delta's will need to use a specific bodyParser. 
+
+The default bodyParser provided by the template will only accept `application/vnd.api+json` and the delta-notifier is sending `application/json` content. Aside from that the body of a delta message may be very large, often several megabytes. By specifying the bodyParser on the route accepting delta messages you can easily modify it when required.
+
+An example
+```js 
+// app.js
+import bodyParser from 'body-parser';
+// ...
+
+app.post("/delta-updates", bodyParser.json({limit: '50mb'}), async function(req, res) {
+//...
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The following environment variables can be configured:
 
   - `NODE_ENV` (default: `production`): either `"development"` or `"production"`. The environment to start the application in. The application live reloads on changes in `"development"` mode.
   - `MAX_BODY_SIZE` (default: `100kb`): max size of the request body. See [ExpressJS documentation](https://expressjs.com/en/resources/middleware/body-parser.html#limit).
+  - `HOST` (default: `0.0.0.0`): The hostname you want the service to bind to.
+  - `PORT` (default: `80`): The port you want the service to bind to
+
 
 ### Mounting `/config`
 You may let users extend the microservice with code.

--- a/helpers/mu/server.js
+++ b/helpers/mu/server.js
@@ -4,6 +4,8 @@ import bodyParser from 'body-parser';
 
 var app = express();
 
+var port = process.env.PORT || '80';
+var hostname = process.env.HOST || '0.0.0.0';
 var bodySizeLimit = process.env.MAX_BODY_SIZE || '100kb';
 
 // parse JSONAPI content type
@@ -35,8 +37,8 @@ const errorHandler = function(err, req, res, next) {
 };
 
 // start server
-app.listen( 80, function() {
-  console.log(`Starting server on port 80 in ${app.get('env')} mode`);
+app.listen( port, hostname, function() {
+  console.log(`Starting server on ${hostname}:${port} in ${app.get('env')} mode`);
 });
 
 export default app;


### PR DESCRIPTION
feature-node-16-support is used by https://github.com/redpencilio/ldes-consumer-service/blob/master/Dockerfile#L1

Would it be possible to update feature-node-16-support?