### PR TITLE
fix feature builds

### DIFF
--- a/.woodpecker/feature.yml
+++ b/.woodpecker/feature.yml
@@ -3,7 +3,7 @@ steps:
     image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO/mu-semtech/semtech}
-      tags: ${CI_COMMIT_SOURCE_BRANCH/\//-}
+      tags: ${CI_COMMIT_BRANCH/\//-}
     secrets: [ docker_username, docker_password ]
 when:
   branch: feature/*


### PR DESCRIPTION
`$CI_COMMIT_SOURCE_BRANCH` is only set in a PR context and not in a regular push context. In a regular push context `$CI_COMMIT_BRANCH` should be used