### PR TITLE
support arm64

### DIFF
--- a/.woodpecker/feature.yml
+++ b/.woodpecker/feature.yml
@@ -1,6 +1,7 @@
 steps:
   build-feature:
     image: woodpeckerci/plugin-docker-buildx
+    platforms: linux/amd64,linux/arm64
     settings:
       repo: ${CI_REPO/mu-semtech/semtech}
       tags: ${CI_COMMIT_BRANCH/\//-}

--- a/.woodpecker/latest.yml
+++ b/.woodpecker/latest.yml
@@ -1,6 +1,7 @@
 steps:
   build-latest:
     image: woodpeckerci/plugin-docker-buildx
+    platforms: linux/amd64,linux/arm64
     settings:
       repo: ${CI_REPO/mu-semtech/semtech}
       tags: latest

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -1,6 +1,7 @@
 steps:
   build-release:
     image: woodpeckerci/plugin-docker-buildx
+    platforms: linux/amd64,linux/arm64
     settings:
       repo: ${CI_REPO/mu-semtech/semtech}
       tags: "${CI_COMMIT_TAG##v}"


### PR DESCRIPTION
this PR updates to woodpecker config to build both a amd64 and arm64 image. it makes sense for base images to support a wider set of platforms. Should allow our dear mac m2 users to have a somewhat faster image and dev environment.