### PR TITLE
include all files in build

### DIFF
--- a/transpile-sources.sh
+++ b/transpile-sources.sh
@@ -61,6 +61,8 @@ cd ..
   ./build/ \
   --out-dir ./typescript-transpilation/ \
   --source-maps true \
+  --copy-files \
+  --no-copy-ignored \
   --extensions ".ts,.js"
 
 rm -Rf ./build

--- a/transpile-sources.sh
+++ b/transpile-sources.sh
@@ -60,8 +60,6 @@ docker-rsync /usr/src/processing/coffeescript-transpilation/ /usr/src/processing
   ./build/ \
   --out-dir ./typescript-transpilation/ \
   --source-maps true \
-  --copy-files \
-  --no-copy-ignored \
   --extensions ".ts,.js"
 
 rm -Rf ./build
@@ -73,6 +71,16 @@ mv typescript-transpilation /usr/src/build
 # transpile them to nodejs in this step, but that breaks SourceMaps.
 docker-rsync /usr/src/processing/coffeescript-transpilation/ /usr/src/build/
 
+# We move all unhandled files (non js, ts, coffee) into the sources for
+# later use.
+
+docker-rsync \
+    --exclude "*.js" \
+    --exclude "*.ts" \
+    --exclude "*.coffee" \
+    --exclude "node_modules/" \
+    --exclude "./Dockerfile" \
+    /usr/src/processing/app/ /usr/src/build/
 
 ##############
 # Node modules


### PR DESCRIPTION
When compiling copy over the non compilable files. typically these are supporting files like json files, hbs, templates, ... that are expected by the app.

Fixes #60 