### PR TITLE
chore: don't change SELinux file attributes

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -12,8 +12,9 @@ function docker-rsync() {
   # Used rsync options:
   # -a: archive, -H: preserve hard links, -A: preserve ACL, -W: no delta transfer
   # -X: extended attributes, -S: efficient sparse files
+  # --filter='-x security.selinux': don't try to change SELinux file attributes
   # --numeric-ids: use uuid by number instead of by name
   # --info: silent output
   # --no-compress: no compression algorithm
-  rsync -aHAWXS --numeric-ids --info= --no-compress $@
+  rsync -aHAWXS --filter='-x security.selinux' --numeric-ids --info= --no-compress $@
 }


### PR DESCRIPTION
On my system, where SELinux is enabled, this gives a lot of errors. Nothing actually breaks, it's just that rsync cannot remove some SELinux related file attributes, but the actual file copying/moving works. It just makes the logs very noisy.

Solution found here: https://unix.stackexchange.com/a/648651