### PR TITLE
always run npm install

### DIFF
--- a/npm-install-dependencies.sh
+++ b/npm-install-dependencies.sh
@@ -2,14 +2,8 @@
 cd /usr/src/app/app/
 if [ -f "/usr/src/app/app/package.json" ]
 then
-    if [[ "$1" == "production" ]] && [ -f "/usr/src/app/app/package-lock.json" ]
-    then
-        echo "Installing dependencies in ci mode"
-        npm ci
-    else
-        echo "Installing dependencies from package.json"
-        npm install
-    fi
+    echo "Installing dependencies from package.json"
+    npm install
 fi
 
 mkdir -p /usr/src/app/app/node_modules/


### PR DESCRIPTION
Since we merge the template package.json into the services package.json the existing package-lock.json of the service will never match with the package-lock.json of the service. 

As such there is no use in trying to do a npm ci, since npm will always fail with 
```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
```

Either the merging needs to also merge the package-lock.json (but I couldn't achieve this easily) or we need to need run a npm install (this PR's proposal)