### PR TITLE
Extract uuid to a separate file

### DIFF
--- a/helpers/mu/index.js
+++ b/helpers/mu/index.js
@@ -1,9 +1,6 @@
 import { app, errorHandler } from './server.js';
 import sparql from './sparql.js';
-import { v1 as uuidV1 } from 'uuid';
-
-// generates a uuid
-const uuid = uuidV1;
+import uuid from './uuid.js';
 
 const mu = {
   app: app,

--- a/helpers/mu/uuid.js
+++ b/helpers/mu/uuid.js
@@ -1,0 +1,6 @@
+import { v1 as uuidV1 } from 'uuid';
+
+// generates a uuid
+const uuid = uuidV1;
+
+export { uuid };


### PR DESCRIPTION
## Description
This extracts the uuid package and uuid export to a separate file.
## Motivation
One of the main problems that the GN team has faced with the javascript template is that if you import anything from the 'mu' package it spins up a server, which is not always desirable, for example while running the tests of your microservice. I will try to address this problem in a future PR by making the server spin up when the microservice starts running instead of when you import from 'mu'.
On the meantime our workaround has been to import the code we needed from the individual files instead for example importing the helpers from 'mu/sparql'. This approach is not possible for the uuid as it's defined and exported in the index.js file. Which leads to the solution being using the main uuid package directly. This solution has many drawbacks and I think diverges from what the mu-javascript-template wants to do (unify the ecosystem).
So what I propose is to extract the uuid export to a new file so we can keep consistent with our workaround while not impacting the other users of the templte until we solve the main problem which I think will take a while
Thanks for coming to my TED talk.
## Testing
Basically this PR should have no impact to the normal use of the template, but now you should be able to do `import { uuid } from 'mu/uuid.js'`