### PR TITLE
Add userOption to set an external endpoint to use for SPARQL requests

### DIFF
--- a/helpers/mu/sparql.js
+++ b/helpers/mu/sparql.js
@@ -12,6 +12,13 @@ const DEBUG_AUTH_HEADERS = env.get('DEBUG_AUTH_HEADERS').asBool();
 
 // builds a new sparqlClient
 function newSparqlClient(userOptions) {
+  if (userOptions.endpoint) {
+    if (DEBUG_AUTH_HEADERS) {
+      console.log(`Not setting auth headers for SPARQL client for external requests to ${userOptions.endpoint}`);
+    }
+    return new SparqlClient(userOptions.endpoint);
+  }
+
   let options = { requestDefaults: { headers: { } } };
 
   if (userOptions.sudo === true) {
@@ -51,6 +58,7 @@ function newSparqlClient(userOptions) {
  * @typedef {Object} QueryOptions
  * @property {boolean?} sudo Execute the query as sudo
  * @property {string?} scope URI of the scope with whith the query is executed.  Use the environment variable `DEFAULT_MU_AUTH_SCOPE` if possible.
+ * @property {string?} endpoint The URL to make the request to if different to `MU_SPARQL_ENDPOINT`. Do not use unless you're making a request outside of the stack as normal auth headers will not be set.
  */
 
 /**


### PR DESCRIPTION
When used, auth headers are not set, so we don't leak any headers from inside the stack.

This is something we need in GN for a service which gets some of it's data from the triplestore (via mu-auth) and other parts from MOW's externally available SPARQL endpoint.