### PR TITLE
Fail build if there are non-zero exit codes in build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,4 +307,4 @@ Use the mu-script `setup-ide` to install these without running in development mo
 Changes to dependencies in `package.json` will be picked up and an updated `package-lock.json` will be copied into the mounted sources provided `package-lock.json` is enabled.  Local packages are installed through the `package-lock.json` and the template's dependencies are merged in.  The `package-lock.json` thus only contains your own dependencies and should not conflict with future upgrades in the template.
 
 ### Custom build commands
-To execute custom bash statements during the image build (e.g. to install aditional system libraries), provide an `on-build.sh` script in the root of your service. It will be automatically picked up and executed by the Docker build.
+To execute custom bash statements during the image build (e.g. to install aditional system libraries), provide an `on-build.sh` script in the root of your service. It will be automatically picked up and executed by the Docker build. Make sure to return a non-zero return code in case of failure, in order to fail the build. For example using `set -eo` to exit on any non-zero statuses or if any part of a pipe fails.

--- a/build-production.sh
+++ b/build-production.sh
@@ -6,6 +6,9 @@
 # so we can warn at runtime in case developers accidentally mount
 # sources without setting the development environment variable.
 
+# Fail build on error
+set -eo pipefail
+
 source ./helpers.sh
 
 # Copy sources from /app to where they can be built

--- a/npm-install-dependencies.sh
+++ b/npm-install-dependencies.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Fail build on error
+set -eo pipefail
+
 source ./helpers.sh
 
 environment=$1

--- a/transpile-sources.sh
+++ b/transpile-sources.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Fail build on error
+set -eo pipefail
+
 source ./helpers.sh
 
 ####

--- a/validate-package-json.sh
+++ b/validate-package-json.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Fail build on error
+set -eo pipefail
+
 cd /usr/src/app/
 node ./validate-package-json.js
 cd /usr/src/app/app/
@@ -6,14 +10,13 @@ cd /usr/src/app/app/
 ## Ensure package.json has module
 if [ -f /usr/src/app/app/package.json ]
 then
-  cat /usr/src/app/app/package.json | jq -e ".type" > /dev/null
-  if [  $? -ne 0 ]
+  PACKAGE_TYPE=`cat /usr/src/app/app/package.json | jq -r ".type"`
+  if [[ "$PACKAGE_TYPE" -eq "null" ]]
   then
     echo '[WARNING] Adding "type": "module" to your package.json.'
     echo 'To remove this warning, add "type": "module" at the same level as "name" in your package.json'
     sed -i '0,/{/s/{/{\n  "type": "module",/' /usr/src/app/app/package.json
   else
-    PACKAGE_TYPE=`cat /usr/src/app/app/package.json | jq -r ".type"`
     if [[ "$PACKAGE_TYPE" -ne "module" ]]
     then
       echo '[WARNING] DIFFERENT TYPE THAN "module" IN package.json; CONTINUING WITH UNSPECIFIED BEHAVIOUR'


### PR DESCRIPTION
Uses `set -eo` to stop a build if any part of the `build-production` script returns a non-zero code, even if it's part of a series of pipes. This can be turned off for particular parts of the scripts if necessary, but it seems like a sensible default.

This caused a problem with a build in GN as a dependency problem did not fail the build but produced an image that would not start.