### PR TITLE
Improve error message for sudo request denial

### DIFF
--- a/helpers/mu/sparql.js
+++ b/helpers/mu/sparql.js
@@ -18,7 +18,7 @@ function newSparqlClient(userOptions) {
     if (env.get("ALLOW_MU_AUTH_SUDO").asBool()) {
       options.requestDefaults.headers['mu-auth-sudo'] = "true";
     } else {
-      throw "Error, sudo request but service lacks ALLOW_MU_AUTH_SUDO header";
+      throw new Error(`Sudo request denied: environment variable ALLOW_MU_AUTH_SUDO is not set to true`);
     }
   }
 


### PR DESCRIPTION
Quality of life improvement: This makes the error message immediately visible in logs and stack traces, rather than appearing as "undefined".

throw new Error("...") creates a proper error object with a .message property.