### PR TITLE
Bump base image to Node 22 and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:20-bookworm
+FROM node:22-bookworm-slim
 
 LABEL maintainer="team@semantic.works"
 
-RUN apt-get update && apt-get -y upgrade && apt-get -y install git openssh-client rsync jq
+RUN apt-get update && apt-get -y upgrade && apt-get -y install --no-install-recommends ca-certificates git openssh-client rsync jq wget \
+    && rm -rf /var/lib/apt/lists/*
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       echo "BUILDING FOR AMD64 through $TARGETPLATFORM"; cd /tmp/ && wget https://github.com/watchexec/watchexec/releases/download/v2.3.2/watchexec-2.3.2-x86_64-unknown-linux-gnu.deb && dpkg -i watchexec-2.3.2-x86_64-unknown-linux-gnu.deb; \

--- a/babel.config.json
+++ b/babel.config.json
@@ -3,7 +3,7 @@
     ["@babel/preset-env",
       {
         "targets": {
-          "node": 18
+          "node": 22
         },
         "modules": false
       }

--- a/run-development.sh
+++ b/run-development.sh
@@ -124,9 +124,8 @@ else
     NODE_PID=$!
     trap 'kill -s SIGUSR2 $NODE_PID' SIGUSR2 # SIGINT and SIGTERM are not necessary here now
 
-    # TODO: Is this ps + while verification step is still necessary?  The
-    # process appeared not to fully exit after `wait`.
-    while ps -p $NODE_PID > /dev/null
+    # check if pid is still running
+    while kill -0 $NODE_PID 2>/dev/null
     do
         wait $NODE_PID
     done

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Node 14",
+  "display": "Node 22",
 
   "compilerOptions": {
-    "lib": ["es2020"],
-    "module": "es2020",
-    "target": "es2020",
+    "lib": ["es2022"],
+    "module": "es2022",
+    "target": "es2022",
     "allowJs": true,
     "noEmit": true,
 


### PR DESCRIPTION
Switches the base image from node:20-bookworm to node:22-bookworm-slim, reducing the image size from ~452 MB to ~168 MB (~3× smaller).

Tested:
  - Production build runs correctly
  - Development mode live reload works correctly (file changes trigger recompile and clean restart without port conflicts)
  -   chrome debugger connected correctly

Notes:
- replaced `ps -p` check with equivalent `kill -0` check (ps is not available in slim image)
- installs ca-certificates and wget explicitly since those were missing from the slim image

